### PR TITLE
Add struct instantiation shortcut syntax

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -477,6 +477,13 @@ impl Interpreter {
 
                 let mut instance_fields = IndexMap::new();
                 for (field_name, field_expr) in fields.iter() {
+                    let field_value = match field_expr {
+                        Expr::Identifier(var_name, _) if var_name == field_name => {
+                            self.evaluate_expr(field_expr)?
+                        }
+                        _ => self.evaluate_expr(field_expr)?,
+                    };
+
                     let Some(expected_type) = struct_fields.get(field_name) else {
                         return Err(Error::new_runtime(
                             format!("Missing field {} in struct {}", field_name, name),
@@ -484,7 +491,6 @@ impl Interpreter {
                         ));
                     };
 
-                    let field_value = self.evaluate_expr(field_expr)?;
                     let field_type = field_value.type_str();
 
                     if field_type != *expected_type {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1261,14 +1261,14 @@ impl Parser {
                 .ok_or_else(|| {
                     Error::new_parse("Expected field name".to_string(), self.current_token().span)
                 })?;
-            if self.current_token().kind != TokenKind::Colon {
-                return Err(Error::new_parse(
-                    "Expected ':' after field name".to_string(),
-                    self.current_token().span,
-                ));
-            }
-            self.advance(); // Consume ':'
-            let field_value = self.parse_expression()?;
+
+            let field_value = if self.current_token().kind == TokenKind::Colon {
+                self.advance(); // Consume ':'
+                self.parse_expression()?
+            } else {
+                Expr::Identifier(field_name.clone(), self.current_token().span)
+            };
+
             fields.push((field_name, field_value));
 
             if self.current_token().kind == TokenKind::Comma {

--- a/tests/scripts/impl.hk
+++ b/tests/scripts/impl.hk
@@ -5,7 +5,7 @@ struct Point {
 
 impl Point {
     fn new(x: int, y: int) -> Point {
-        Point { x: x, y: y }
+        Point { x, y }
     }
 
     fn distance_from_origin(self) -> int {

--- a/tests/scripts/struct.hk
+++ b/tests/scripts/struct.hk
@@ -3,11 +3,12 @@ struct Person {
     age: int,
 }
 
-let person = Person { name: "Felipe", age: 44 };
+let name = "Felipe";
+let age = 44;
+let person = Person { name, age };
 println(person.name);
 println(person.age);
 println(person);
 
 person.age = 22;
 println(person.age);
-


### PR DESCRIPTION
Add support for struct instantiation shortcut syntax.

* **Parser Changes:**
  - Update `parse_struct_init` function in `src/parser.rs` to handle the new shortcut syntax for struct instantiation.
  - Modify `parse_struct_init` to check if the field name is the same as the variable name and handle accordingly.

* **Interpreter Changes:**
  - Update `evaluate_expr` function in `src/interpreter.rs` to handle the new shortcut syntax for struct instantiation.
  - Modify `evaluate_expr` to check if the field name is the same as the variable name and handle accordingly.

* **Test Updates:**
  - Update `tests/scripts/struct.hk` to use the new shortcut syntax for struct instantiation.
  - Update `tests/scripts/impl.hk` to use the new shortcut syntax for struct instantiation.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fcoury/husk?shareId=20bace29-feb3-4aa0-859f-be3e7c4f4d7d).